### PR TITLE
Add persistent detection overlay and validation indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 python3 -m src.app
 
 ## Atajos
-q: salir · d: cajas · h: HUD · 1/2/3/4: escala# .
+q: salir · d: cajas · h: HUD · 1/2/3/4: escala +/-.

--- a/src/conf.py
+++ b/src/conf.py
@@ -15,7 +15,7 @@ ESCALA_PREVIEW_INICIAL = 0.5      # 0.3–1.0 (teclas 1–4)
 DECODIFICAR_CADA_N = 3            # cada N ciclos del hilo decodificador
 VENTANA_TAMANIO = 5               # evaluamos N frames por lote (best focus)
 
-DIBUJAR_CAJAS_INICIAL = False     # tecla 'd'
+DIBUJAR_CAJAS_INICIAL = True      # tecla 'd'
 HUD_ACTIVO_INICIAL = True         # tecla 'h'
 
 # Simbolos a detectar
@@ -39,5 +39,5 @@ BD_NOMBRE = "bd_test"
 #   "maquina"  => toggle en registros_maquina por codigo_maquina
 MODO_REGISTRO = "operador"
 
-# Anti-rebote (evitar multiples activaciones por el mismo ccdigo en frames consecutivos)
+# Anti-rebote (evitar multiples activaciones por el mismo código en frames consecutivos)
 COOLDOWN_MILLIS = 1500

--- a/src/deco.py
+++ b/src/deco.py
@@ -53,6 +53,7 @@ class HiloDecodificador:
 
             # Decodificar
             detecciones = decode(mejor_gray, symbols=self.simbolos)
+            self.estado.actualizar_detecciones(detecciones)
             if detecciones:
                 d = detecciones[0]
                 valor = d.data.decode("utf-8", errors="ignore")
@@ -65,8 +66,16 @@ class HiloDecodificador:
                     try:
                         mensaje = self.validador.procesar_codigo(valor, tipo)
                         print(mensaje)  # <-- indicador claro en consola
+                        exito = mensaje.startswith("[OK]")
+                        self.estado.notificar_validacion(mensaje, exito)
                     except Exception as e:
                         print(f"[ERROR] Validación BD: {e}")
+                        self.estado.notificar_validacion(f"[ERROR] Validación BD: {e}", False)
+                else:
+                    mensaje = f"{tipo} aceptado: {valor}"
+                    self.estado.notificar_validacion(mensaje, True)
+            else:
+                self.estado.actualizar_meta("", "", mejor_enfoque)
 
             time.sleep(0.0)  # ceder CPU
 

--- a/src/rend.py
+++ b/src/rend.py
@@ -37,8 +37,12 @@ class HiloRender:
             if escala != 1.0:
                 vis = cv2.resize(frame, (0, 0), fx=escala, fy=escala, interpolation=cv2.INTER_LINEAR)
 
-            if self.estado.dibujar_cajas:
-                pass
+            detecciones = self.estado.leer_detecciones()
+            dibujar_cajas(vis, detecciones, escala=escala)
+
+            mensaje_validacion, indicador_activo = self.estado.leer_validacion()
+            if indicador_activo:
+                self._dibujar_indicador_aceptado(vis, mensaje_validacion)
 
             # HUD
             valor, tipo, mejor_enfoque = self.estado.leer_meta()
@@ -53,8 +57,7 @@ class HiloRender:
                 print("[INFO] salida solicitada")
                 self.estado.detener = True
             elif key == ord('d'):
-                self.estado.dibujar_cajas = not self.estado.dibujar_cajas
-                print(f"[INFO] cajas {'on' if self.estado.dibujar_cajas else 'off'}")
+                print("[INFO] El resaltado de cajas está siempre activo.")
             elif key == ord('h'):
                 self.estado.hud_activo = not self.estado.hud_activo
                 print(f"[INFO] HUD {'on' if self.estado.hud_activo else 'off'}")
@@ -69,3 +72,16 @@ class HiloRender:
 
         cv2.destroyAllWindows()
         print("[OK] ventana cerrada")
+
+    def _dibujar_indicador_aceptado(self, frame, mensaje: str):
+        h, w = frame.shape[:2]
+        alto = max(60, int(0.12 * h))
+        overlay = frame.copy()
+        cv2.rectangle(overlay, (0, h - alto), (w, h), (0, 180, 0), -1)
+        cv2.addWeighted(overlay, 0.6, frame, 0.4, 0, frame)
+        texto_ok = "CÓDIGO ACEPTADO"
+        cv2.putText(frame, texto_ok, (10, h - alto + 30),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 255, 255), 2)
+        if mensaje:
+            cv2.putText(frame, mensaje, (10, h - 15),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.7, (240, 240, 240), 2)

--- a/src/util.py
+++ b/src/util.py
@@ -22,7 +22,7 @@ def establecer_propiedades_camara(captura, ancho, alto, fps, fourcc_texto="MJPG"
 def varianza_laplaciana(gray):
     return cv2.Laplacian(gray, cv2.CV_64F).var()
 
-def dibujar_cajas(frame, detecciones):
+def dibujar_cajas(frame, detecciones, escala=1.0):
     """
     Dibuja rectángulos sobre el frame con base en rect de pyzbar.
     Usa r.left, r.top, r.width, r.height (propiedades estándar).
@@ -32,6 +32,11 @@ def dibujar_cajas(frame, detecciones):
     for det in detecciones:
         r = det.rect
         x, y, w, h = int(r.left), int(r.top), int(r.width), int(r.height)
+        if escala != 1.0:
+            x = int(round(x * escala))
+            y = int(round(y * escala))
+            w = int(round(w * escala))
+            h = int(round(h * escala))
         cv2.rectangle(frame, (x, y), (x+w, y+h), (0,255,0), 2)
         etiqueta = det.type
         (tw, th), base = cv2.getTextSize(etiqueta, cv2.FONT_HERSHEY_SIMPLEX, 0.6, 2)

--- a/tests/test_validador.py
+++ b/tests/test_validador.py
@@ -1,0 +1,115 @@
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+_fake_symbols = types.SimpleNamespace(
+    EAN13='EAN13', EAN8='EAN8', UPCA='UPCA', UPCE='UPCE',
+    CODE39='CODE39', CODE93='CODE93', CODE128='CODE128',
+    I25='I25', DATABAR='DATABAR', DATABAR_EXP='DATABAR_EXP',
+    CODABAR='CODABAR', PDF417='PDF417', QRCODE='QRCODE'
+)
+
+pyzbar_module = types.ModuleType('pyzbar')
+pyzbar_pyzbar = types.ModuleType('pyzbar.pyzbar')
+pyzbar_pyzbar.ZBarSymbol = _fake_symbols
+pyzbar_module.pyzbar = pyzbar_pyzbar
+sys.modules.setdefault('pyzbar', pyzbar_module)
+sys.modules['pyzbar.pyzbar'] = pyzbar_pyzbar
+
+pymysql_module = types.ModuleType('pymysql')
+pymysql_module.connect = lambda *args, **kwargs: None
+pymysql_cursors = types.ModuleType('pymysql.cursors')
+pymysql_cursors.DictCursor = object
+pymysql_module.cursors = pymysql_cursors
+sys.modules.setdefault('pymysql', pymysql_module)
+sys.modules['pymysql.cursors'] = pymysql_cursors
+
+from src.validador import ValidadorRegistros
+
+
+class FakeBD:
+    def __init__(self):
+        self.operadores = {
+            "G1": {
+                "id_operador": 1,
+                "id_maquina_asignada": 99,
+                "activo": True,
+            }
+        }
+        self.maquinas = {
+            "M1": {
+                "id_maquina": 7,
+                "activo": True,
+            }
+        }
+        self.registros_operador = []
+        self.registros_maquina = []
+
+    def probar_conexion(self):
+        return True, "ok"
+
+    def buscar_operador_por_gafete(self, numero_gafete):
+        return self.operadores.get(numero_gafete)
+
+    def insertar_registro_operador(self, **datos):
+        self.registros_operador.append(datos)
+
+    def buscar_maquina_por_codigo(self, codigo):
+        return self.maquinas.get(codigo)
+
+    def insertar_registro_maquina(self, **datos):
+        self.registros_maquina.append(datos)
+
+
+class ValidadorTests(unittest.TestCase):
+    def test_debounce_respeta_cooldown(self):
+        fake_bd = FakeBD()
+        with patch('src.validador.BaseDatos', return_value=fake_bd):
+            validador = ValidadorRegistros(MagicMock())
+
+        with patch('src.validador.time.time', side_effect=[1.0, 1.1, 3.0]):
+            self.assertFalse(validador._debounce("ABC123"))
+            self.assertTrue(validador._debounce("ABC123"))
+            self.assertFalse(validador._debounce("ABC123"))
+
+    def test_toggle_operador_abre_y_cierra(self):
+        fake_bd = FakeBD()
+        with patch('src.validador.BaseDatos', return_value=fake_bd):
+            validador = ValidadorRegistros(MagicMock())
+
+        with patch('src.validador.MODO_REGISTRO', 'operador'), \
+             patch('src.validador.time.time', side_effect=[0.0, 5.0]):
+            mensaje_apertura = validador.procesar_codigo('G1', 'QRCODE')
+            mensaje_cierre = validador.procesar_codigo('G1', 'QRCODE')
+
+        self.assertIn('Apertura OPERADOR', mensaje_apertura)
+        self.assertIn('Cierre OPERADOR', mensaje_cierre)
+        self.assertEqual(len(fake_bd.registros_operador), 1)
+        registro = fake_bd.registros_operador[0]
+        self.assertEqual(registro['id_operador'], 1)
+        self.assertEqual(registro['id_maquina'], 99)
+        self.assertIn('inicio', registro)
+        self.assertIn('fin', registro)
+
+    def test_toggle_maquina_abre_y_cierra(self):
+        fake_bd = FakeBD()
+        with patch('src.validador.BaseDatos', return_value=fake_bd):
+            validador = ValidadorRegistros(MagicMock())
+
+        with patch('src.validador.MODO_REGISTRO', 'maquina'), \
+             patch('src.validador.time.time', side_effect=[10.0, 15.0]):
+            mensaje_apertura = validador.procesar_codigo('M1', 'CODE128')
+            mensaje_cierre = validador.procesar_codigo('M1', 'CODE128')
+
+        self.assertIn('Apertura MÁQUINA', mensaje_apertura)
+        self.assertIn('Cierre MÁQUINA', mensaje_cierre)
+        self.assertEqual(len(fake_bd.registros_maquina), 1)
+        registro = fake_bd.registros_maquina[0]
+        self.assertEqual(registro['id_maquina'], 7)
+        self.assertIn('inicio', registro)
+        self.assertIn('fin', registro)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the README shortcut typo and correct the anti-rebounce documentation in the configuration
- always render detection boxes, add a barcode acceptance banner, and propagate detection metadata through the shared state
- add state-driven validation notifications and new unit tests covering debounce logic and toggle flows

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68e01c7a76d0832381df918618a3d8e0